### PR TITLE
Add default steps to post-deploy plan

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -20,6 +20,11 @@ Short description of the problem or opportunity for improvement
 - Test Cases (required)
 - Edge Cases (all known edge cases are required)
 
+#### [How to QA](https://beamdental.atlassian.net/wiki/spaces/ENG/pages/230293509/How+to+QA)
+
 ## Post-deploy plan
 
-#### [How to QA](https://beamdental.atlassian.net/wiki/spaces/ENG/pages/230293509/How+to+QA)
+- [ ] Manually validate the change in production if applicable
+- [ ] Monitor #rollbar-errors for new events
+- [ ] Add more specific steps based on the change
+


### PR DESCRIPTION
* Move the "How to QA" link into the Validation section
* Add some default post-deploy steps to think about

#### [JIRA Issue](https://beamdental.atlassian.net/browse/PW-418)

#### Ephemeral Environment or Staging Link: 

## Context

Short description of the problem or opportunity for improvement

## Changes

- [ ] Task 1
- [ ] Task 2
- [ ] Task 3

## Validation

- Steps to reproduce issue (required if it's tech debt or a bug)
- Steps to see the acceptance criteria (required)
- Full workflow and additional screens affected (recommended)
- Test Cases (required)
- Edge Cases (all known edge cases are required)

## Post-deploy plan

#### [How to QA](https://beamdental.atlassian.net/wiki/spaces/ENG/pages/230293509/How+to+QA)
