### PR TITLE
ignore dependency bumps in e2e status check

### DIFF
--- a/actions/e2e-check/main.js
+++ b/actions/e2e-check/main.js
@@ -17,7 +17,9 @@ const IGNORE_BRANCH_PREFIXES = ['dependabot/', 'renovate/']
 console.log(context)
 const issue_number = context.payload.number || context.issue.number
 const branchName =
-  context.payload.pull_request && context.payload.pull_request.head
+  context.payload.pull_request &&
+  context.payload.pull_request.head &&
+  context.payload.pull_request.head.ref
 const shouldIgnoreBranch =
   branchName &&
   IGNORE_BRANCH_PREFIXES.find(prefix => branchName.startsWith(prefix))

--- a/actions/e2e-check/main.js
+++ b/actions/e2e-check/main.js
@@ -12,11 +12,15 @@ const IGNORE_COMMAND = 'e2e ignore'
 const STATUS_MARKER = '::E2E Check::'
 const INSTRUCTIONS = `If E2E is needed for this PR, please run it by commenting \`${TRIGGER_COMMAND} <options>\`. If this PR will not need E2E, you can ignore any future notifications by commenting \`${IGNORE_COMMAND}\`.`
 
-console.log(
-  context,
-  context.payload.pull_request && context.payload.pull_request.head,
-)
+const IGNORE_BRANCH_PREFIXES = ['dependabot/', 'renovate/']
+
+console.log(context)
 const issue_number = context.payload.number || context.issue.number
+const branchName =
+  context.payload.pull_request && context.payload.pull_request.head
+const shouldIgnoreBranch =
+  branchName &&
+  IGNORE_BRANCH_PREFIXES.find(prefix => branchName.startsWith(prefix))
 
 const getComments = async () =>
   (
@@ -112,7 +116,7 @@ const run = async () => {
     return updateStatus('success', '')
   }
 
-  if (shouldIgnore) return clear()
+  if (shouldIgnore || shouldIgnoreBranch) return clear()
 
   if (!latestE2EComment) return fail('E2E has not been run on this PR.')
 

--- a/actions/e2e-check/main.js
+++ b/actions/e2e-check/main.js
@@ -24,6 +24,8 @@ const shouldIgnoreBranch =
   branchName &&
   IGNORE_BRANCH_PREFIXES.find(prefix => branchName.startsWith(prefix))
 
+console.log(branchName)
+
 const getComments = async () =>
   (
     await octokit.issues.listComments({

--- a/actions/e2e-check/main.js
+++ b/actions/e2e-check/main.js
@@ -22,7 +22,8 @@ const branchName =
   context.payload.pull_request.head.ref
 const shouldIgnoreBranch =
   branchName &&
-  IGNORE_BRANCH_PREFIXES.find(prefix => branchName.startsWith(prefix))
+  (IGNORE_BRANCH_PREFIXES.find(prefix => branchName.startsWith(prefix)) ||
+    branchName.indexOf('skip-e2e/') > -1)
 
 console.log(branchName)
 


### PR DESCRIPTION
#### [JIRA Issue](https://beamdental.atlassian.net/browse/PW-418)

#### Ephemeral Environment or Staging Link: 

## Context

This PR adds a feature to our e2e status check to ignore branch prefixes, specifically ones that come from Dependabot and Renovate.

## Validation

See that https://github.com/beamtech/authentication-server/pull/351 is requiring no E2E

#### [How to QA](https://beamdental.atlassian.net/wiki/spaces/ENG/pages/230293509/How+to+QA)
