### PR TITLE
add dotfiles to platform-js-root-wildcard.yml

### DIFF
--- a/shared-labels/platform-js-root-wildcard.yml
+++ b/shared-labels/platform-js-root-wildcard.yml
@@ -1,2 +1,4 @@
 area/platform:
   - any: ['*', '!pnpm-lock.yaml']
+  - any: ['.*', '!pnpm-lock.yaml']
+  - any: ['.**/**/*', '!pnpm-lock.yaml']

--- a/shared-labels/platform-js-root-wildcard.yml
+++ b/shared-labels/platform-js-root-wildcard.yml
@@ -1,4 +1,3 @@
 area/platform:
   - any: ['*', '!pnpm-lock.yaml']
   - any: ['.*', '!pnpm-lock.yaml']
-  - any: ['.**/**/*', '!pnpm-lock.yaml']


### PR DESCRIPTION
`area/platform` was not being labeled on PRs that changed dotfiles at the root. This PR fixes this.