### PR TITLE
Tweak area/platform label exceptions

### DIFF
--- a/shared-labels/platform-base.yml
+++ b/shared-labels/platform-base.yml
@@ -4,7 +4,7 @@ area/platform:
   - '**/docker-compose.@(yml|yaml)'
   - 'migrations.yml'
   - 'deployment-settings.yaml'
-  - 'scripts/**/*'
+  - any: ['scripts/**/*', '!scripts/one_time/**/*']
   - '.buildkite/**/*'
   - '.docker/**/*'
   - '.dockerignore'

--- a/shared-labels/platform-js-root-wildcard.yml
+++ b/shared-labels/platform-js-root-wildcard.yml
@@ -1,3 +1,3 @@
 area/platform:
-  - any: ['*', '!pnpm-lock.yaml']
-  - any: ['.*', '!pnpm-lock.yaml']
+  - any: ['*', '!pnpm-lock.yaml', '!package.json']
+  - any: ['.*', '!pnpm-lock.yaml', '!package.json']

--- a/shared-labels/platform-js-root.yml
+++ b/shared-labels/platform-js-root.yml
@@ -9,7 +9,6 @@ area/platform:
   - '.nvmrc'
   - '.yarnrc'
   - '.pnpmfile.cjs'
-  - 'package.json'
   - 'commitlint.config.js'
   - 'lerna.json'
   - 'renovate.json'

--- a/shared-labels/platform-ruby.yml
+++ b/shared-labels/platform-ruby.yml
@@ -1,6 +1,6 @@
 area/platform:
   - 'config.ru'
-  - 'config/**/*'
+  - any: ['config/**/*', '!config/routes.rb']
   - 'lib/**/*'
   - 'spec/spec_helper.rb'
   - 'spec/rails_helper.rb'


### PR DESCRIPTION
## Context

We've been noticing PRs come through with the area/platform label that should not pertain to platform. This PR adds some exceptions:
- Exclude `/scripts/one_time`
- Exclude `/config/routes.rb`
- Exclude `package.json` - together with adding it back in for js-frontend only (https://github.com/beamtech/js-frontend/pull/4235), this serves our goals

## Validation

1. Ensure that [this PR](https://github.com/beamtech/js-frontend/pull/4236) does NOT have the `area/platform` label because its base uses this branch for its labeler presets.
2. Ensure that [this PR](https://github.com/beamtech/js-frontend/pull/4237) DOES have the `area/platform` label because although its base uses this branch for its labeler presets, it also applies the change in https://github.com/beamtech/js-frontend/pull/4235/files.
3. Ensure that [this PR](https://github.com/beamtech/beam-api/pull/8769) does NOT have the `area/platform` label

#### [How to QA](https://beamdental.atlassian.net/wiki/spaces/ENG/pages/230293509/How+to+QA)
